### PR TITLE
Sdc micro next

### DIFF
--- a/R/suda2.R
+++ b/R/suda2.R
@@ -175,7 +175,7 @@ print.suda2 <- function(x, ...) {
   SEQ <- seq(0, 0.7, 0.1) + .Machine$double.eps
   DISSudaScore <- c("0",paste(">", c("0.0",seq(0.1, 0.7, 0.1))))
   tab <- table(cut(x$disScore, breaks = c(-1, SEQ, Inf)))
-  res <- data.frame(thresholds = DISSudaScore, number = as.numeric(tab))
+  res <- data.frame(Thresholds = DISSudaScore, number = as.numeric(tab))
   cat("\nDis suda scores table: \n")
   cat("- - - - - - - - - - - \n")
   print(res)

--- a/R/suda2.R
+++ b/R/suda2.R
@@ -175,7 +175,7 @@ print.suda2 <- function(x, ...) {
   SEQ <- seq(0, 0.7, 0.1) + .Machine$double.eps
   DISSudaScore <- c("0",paste(">", c("0.0",seq(0.1, 0.7, 0.1))))
   tab <- table(cut(x$disScore, breaks = c(-1, SEQ, Inf)))
-  res <- data.frame(Thresholds = DISSudaScore, number = as.numeric(tab))
+  res <- data.frame(thresholds = DISSudaScore, number = as.numeric(tab))
   cat("\nDis suda scores table: \n")
   cat("- - - - - - - - - - - \n")
   print(res)

--- a/inst/shiny/sdcApp/controllers/ui_categorical.R
+++ b/inst/shiny/sdcApp/controllers/ui_categorical.R
@@ -437,7 +437,7 @@ output$ui_kAnon <- renderUI({
   out <- list(out, fluidRow(column(12, uiOutput("kanon_strata"), align="center")))
   out <- list(out, fluidRow(
     column(12, uiOutput("kanon_use_importance"), align="center"),
-    column(12, helpText("Tip – The total number of suppressions is likely to increase by specifying an importance vector. Specifying an importance vector can affect the computation time."), align="center")
+    column(12, helpText("Tip - The total number of suppressions is likely to increase by specifying an importance vector. Specifying an importance vector can affect the computation time."), align="center")
   ))
   out <- list(out, uiOutput("ui_kanon_importanceInputs")) # might be NULL
 

--- a/inst/shiny/sdcApp/controllers/ui_results_categorical.R
+++ b/inst/shiny/sdcApp/controllers/ui_results_categorical.R
@@ -295,9 +295,11 @@ output$ui_rescat_suda2 <- renderUI({
     }
 
     fluidRow(
-      column(12, h5(paste0("Thresholds (DisFraction=",suda2$DisFraction,")")), align="center"),
+      column(12, h5(strong(paste0("Suda scores (sampling fraction is ",suda2$DisFraction,")"))), align="center"),
+      column(12, p("The table below shows the frequencies of the records with a suda score in the specified intervals."), align="center"),
       column(12, renderTable(suda2$thresholds), align="center"),
-      column(12, h5("Attribute contributions"), align="center"),
+      column(12, h5(strong("Attribute contributions")), align="center"),
+      column(12, p("The table below shows the contribution of each categorical key variable to the SUDA scores. The contribution of a variable is the percentage of the total MSUs in the file that include this variable."), align="center"),
       column(12, renderTable(suda2$attribute_contributions), align="center")
     )
   })


### PR DESCRIPTION
- Fix dash that was displayed wrongly
- Add some more explanation to the suda page

Question:
The vignette states on suda that 'The first table summarizes the suda2 scores that have been obtained. It shows for 8 thresholds, the number of records having suda2 scores greater than this value.' 

However, it seems that it are actually the values in the intervals 0-0.1, 0.1-0.2, etc., which is confirmed that the total is equal to the sample size 4580 (testdata in GUI). If it would be the suda2 scores greater than these thresholds, the records appearing in >0.6, should also appear in >0.5, >0.4, >0.3, etc. (see screenshot below).
 
Can we change the label of the first column to 'interval' (now 'thresholds'), the label of the second column to 'number of records' (now 'number') and the values in the first column to 0-0.1, 0.1-0.2, ...0.6-0.7, >0.7 (now >0, >0.1, >0.2, ...) for clarity? This would make it clearer for the user what is actually shown in the table.


![image](https://cloud.githubusercontent.com/assets/8253935/21050335/660c0310-be1a-11e6-8501-35977f5e1c72.png)
 