### PR TITLE
Add info on deleted variables with all missing values to microdata page

### DIFF
--- a/R/GUIfunctions.R
+++ b/R/GUIfunctions.R
@@ -444,7 +444,12 @@ readMicrodata <- function(path, type, convertCharToFac=TRUE, drop_all_missings=T
   if (drop_all_missings) {
     # drop all variables that are NA-only
     keep <- which(sapply(res, function(x) sum(is.na(x))!=length(x)))
+    dropped <- colnames(res)[-keep]
     res <- res[,keep,drop=FALSE]
+    # save names of dropped variables
+    if(length(dropped) > 0){
+      attr(res, "dropped") <- dropped
+    }
   }
 
   if (type=="stata") {

--- a/inst/shiny/sdcApp/controllers/ui_modify_data.R
+++ b/inst/shiny/sdcApp/controllers/ui_modify_data.R
@@ -579,21 +579,33 @@ output$ui_reset_var <- renderUI({
 output$ui_show_microdata <- renderUI({
   my_data_dt = reactive({
     datatable(inputdata(),
-    rownames = FALSE,
-    selection="none",
-    options = list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=25))
+              rownames = FALSE,
+              selection="none",
+              options = list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=25))
   })
   #, options = list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=25), filter="top", rownames=FALSE
   output$tab_inputdata <- DT::renderDataTable({
     my_data_dt()
   })
-
+  
   txt_microdata <- paste0("In this tab you can manipulate the data to prepare for setting up an object of class",code("sdcMicroObj"),"in the Anonymize tab. ")
   txt_microdata <- paste0(txt_microdata, "The loaded dataset is",code(obj$microfilename),"and consists of",code(nrow(obj$inputdata)),"observations and ",code(ncol(obj$inputdata)),"variables.")
-  txt_microdata <- paste0(txt_microdata, code(attributes(obj$inputdata)),":")
+  if(is.null(attr(obj$inputdata, "dropped"))){
+    txt_microdata <- paste0(txt_microdata, "No variables were dropped because of all missing values.")
+  }else{
+    txt_microdata <- paste0(txt_microdata, code(length(attr(obj$inputdata, "dropped"))), "variable(s) was/were dropped because of all missing values: ")
+    #lapply(attr(obj$inputdata, "dropped"), function(x) {txt_microdata <- paste0(txt_microdata, x)})
+    #attr(obj$inputdata, "dropped")
+  }
   out <- fluidRow(
-    column(12, h4("Loaded microdata"), align="center"),
-    column(12, p(HTML(txt_microdata)), align="center"))
+    column(12, h4("Loaded microdata"), align="center"))
+  if(is.null(attr(obj$inputdata, "dropped"))){
+    out <- fluidRow(
+      column(12, p(HTML(txt_microdata)), align="center"))
+  }else{
+    out <- fluidRow(
+      column(12, list(HTML(txt_microdata), code(lapply(attr(obj$inputdata, "dropped"), function(x) {x}))), align="center"))
+  }
   out <- list(out, fluidRow(
     column(12, dataTableOutput("tab_inputdata"))))
   return(out)

--- a/inst/shiny/sdcApp/controllers/ui_modify_data.R
+++ b/inst/shiny/sdcApp/controllers/ui_modify_data.R
@@ -600,11 +600,11 @@ output$ui_show_microdata <- renderUI({
   out <- fluidRow(
     column(12, h4("Loaded microdata"), align="center"))
   if(is.null(attr(obj$inputdata, "dropped"))){
-    out <- fluidRow(
-      column(12, p(HTML(txt_microdata)), align="center"))
+    out <- list(out, fluidRow(
+      column(12, p(HTML(txt_microdata)), align="center")))
   }else{
-    out <- fluidRow(
-      column(12, list(HTML(txt_microdata), code(lapply(attr(obj$inputdata, "dropped"), function(x) {x}))), align="center"))
+    out <- list(out, fluidRow(
+      column(12, list(HTML(txt_microdata), code(lapply(attr(obj$inputdata, "dropped"), function(x) {x}))), align="center")))
   }
   out <- list(out, fluidRow(
     column(12, dataTableOutput("tab_inputdata"))))

--- a/inst/shiny/sdcApp/controllers/ui_modify_data.R
+++ b/inst/shiny/sdcApp/controllers/ui_modify_data.R
@@ -590,6 +590,7 @@ output$ui_show_microdata <- renderUI({
 
   txt_microdata <- paste0("In this tab you can manipulate the data to prepare for setting up an object of class",code("sdcMicroObj"),"in the Anonymize tab. ")
   txt_microdata <- paste0(txt_microdata, "The loaded dataset is",code(obj$microfilename),"and consists of",code(nrow(obj$inputdata)),"observations and ",code(ncol(obj$inputdata)),"variables.")
+  txt_microdata <- paste0(txt_microdata, code(attributes(obj$inputdata)),":")
   out <- fluidRow(
     column(12, h4("Loaded microdata"), align="center"),
     column(12, p(HTML(txt_microdata)), align="center"))


### PR DESCRIPTION
As suggested by Cathrine, a proposal to include information on the deleted variables due to all missing values to remind the user.