### PR TITLE
Prevent using backslash in path

### DIFF
--- a/inst/shiny/sdcApp/controllers/ui_about.R
+++ b/inst/shiny/sdcApp/controllers/ui_about.R
@@ -32,6 +32,9 @@ output$btn_update_export_path <- renderUI({
   if (!dir.exists(input$path_export_data)) {
     return(myActionButton("btn_update_export_path_xxx", "The specified directory does not exist, thus the path can't be updated", btn.style="danger"))
   }
+  if (grepl("\\", input$path_export_data, fixed=TRUE)){
+    return(myActionButton("btn_update_export_path_xxx", "Use '/' instead of backslash in the path!", btn.style="danger"))
+  }
   if (file.access(input$path_export_data, mode=2)!=0) {
     return(myActionButton("btn_update_export_path_xxx", "The specified directory is not writeable, thus the path can't be updated!", btn.style="danger"))
   }


### PR DESCRIPTION
Check whether / instead of \ is used. On a Windows machine, a copied path will contain \ . Currently, the GUI allows this and stores the string with \ . See the following screenshot:
![capture1](https://cloud.githubusercontent.com/assets/8253935/25809080/4b054320-340c-11e7-8d24-e3a18df77c4b.PNG)
However, this leads to problems later on when the path is used. For instance while exporting data. The GUI greys out and the console shows
![image](https://cloud.githubusercontent.com/assets/8253935/25809129/67200a40-340c-11e7-9d7e-87cffcd6c691.png)

which is hard to interpret for the user.

Therefore, I suggest an additional check when entering the path checking whether it contains \ and if so disallowing to set the path until the / are replaced with \ .

![image](https://cloud.githubusercontent.com/assets/8253935/25809337/ed1aea34-340c-11e7-8501-f89f506a9753.png)

