### PR TITLE
Change number of lines in data table and export table

### DIFF
--- a/inst/shiny/sdcApp/controllers/ui_export_data.R
+++ b/inst/shiny/sdcApp/controllers/ui_export_data.R
@@ -45,7 +45,7 @@ output$ui_export_data <- renderUI({
   output$dt_exportData <- DT::renderDataTable({
     req(input$rb_export_randomizeorder)
     exportData()
-  }, options=list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=10), rownames=FALSE)
+  }, options=list(scrollX=TRUE, lengthMenu=list(c(10, 20, 50, 100, -1), c('10', '20', '50', '100', 'All')), pageLength=10), rownames=FALSE)
 
   # specific (gui)-options for csv-export
   output$ui_export_csv <- renderUI({

--- a/inst/shiny/sdcApp/controllers/ui_modify_data.R
+++ b/inst/shiny/sdcApp/controllers/ui_modify_data.R
@@ -581,7 +581,7 @@ output$ui_show_microdata <- renderUI({
     datatable(inputdata(),
               rownames = FALSE,
               selection="none",
-              options = list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=25))
+              options = list(scrollX=TRUE, lengthMenu=list(c(20, 50, 100, -1), c('20', '50', '100', 'All')), pageLength=20))
   })
   #, options = list(scrollX=TRUE, lengthMenu=list(c(10, 25, 100, -1), c('10', '20', '100', 'All')), pageLength=25), filter="top", rownames=FALSE
   output$tab_inputdata <- DT::renderDataTable({


### PR DESCRIPTION
Data table: default 20 (fits better on screen), align default and choice (was 25 vs '20') and give option 20, 50, 100, all (10 seems to be not needed here)
Export: Correct (25, '20') and give options 10, 20, 50 ,100, all