### PR TITLE
Fix error on the tabulation page when no pram variables are selected

### DIFF
--- a/inst/shiny/sdcApp/controllers/ui_results_categorical.R
+++ b/inst/shiny/sdcApp/controllers/ui_results_categorical.R
@@ -473,8 +473,11 @@ output$ui_bivariate_tab <- renderUI({
   })
   output$biv_tab_m <- renderTable({
     req(input$sel_catvar1)
-    #df <- cbind(get_manipKeyVars(), get_manipPramVars())
-    if (!is.null(get_manipPramVars())) {df <- cbind(get_manipKeyVars(), get_manipPramVars())} else {df <- get_manipKeyVars()}
+    if (!is.null(get_manipPramVars())) {
+      df <- cbind(get_manipKeyVars(), get_manipPramVars())
+    } else {
+      df <- get_manipKeyVars()
+    }
     vars <- c(input$sel_catvar1, input$sel_catvar2)
     if (vars[2]=="none") {
       tab <- addmargins(table(df[[vars[1]]], useNA="always"))

--- a/inst/shiny/sdcApp/controllers/ui_results_categorical.R
+++ b/inst/shiny/sdcApp/controllers/ui_results_categorical.R
@@ -473,7 +473,8 @@ output$ui_bivariate_tab <- renderUI({
   })
   output$biv_tab_m <- renderTable({
     req(input$sel_catvar1)
-    df <- cbind(get_manipKeyVars(), get_manipPramVars())
+    #df <- cbind(get_manipKeyVars(), get_manipPramVars())
+    if (!is.null(get_manipPramVars())) {df <- cbind(get_manipKeyVars(), get_manipPramVars())} else {df <- get_manipKeyVars()}
     vars <- c(input$sel_catvar1, input$sel_catvar2)
     if (vars[2]=="none") {
       tab <- addmargins(table(df[[vars[1]]], useNA="always"))


### PR DESCRIPTION
Not selecting any pram variables results in an error on the tabulation page:

![schermafbeelding 2017-05-28 om 09 14 41](https://cloud.githubusercontent.com/assets/8253935/26529625/ae227592-43c3-11e7-87ef-d25ed34974bd.png)

The problem occurs because get_manipPramVars() returns NULL in that case and the cbind of the data.frame with the key variables and NULL generates the error:

```
Error in data.frame(..., check.names = FALSE) : 
  arguments imply differing number of rows: 4580, 0
```

I proposed a very simple solution with a check on the result of get_manipPramVars(), which resolves this problem.
