### PR TITLE
Correct summary stats in GUI

### DIFF
--- a/R/printFunctions.R
+++ b/R/printFunctions.R
@@ -442,12 +442,19 @@ definition = function(x, type = "kAnon", docat=TRUE, ...) {
       "numVars"=numvars,
       "results"=list()
     )
+    anyChanges <- FALSE # Check if any changes
     for (i in 1:ncol(nv_o)) {
       if (identical(nv_o[,i], nv_m[,i])) {
+        # Add identical columns to output for GUI
+        summary_o <- summary_m <- summary(nv_o[,i])
+        dt <- as.data.table(rbind(c("orig",as.numeric(summary_o)), c("modified",as.numeric(summary_m))))
+        setnames(dt, c("Type",names(summary_o)))
+        out$results[[length(out$results)+1]] <- dt
         if (docat) {
           cat(paste0(tabsp,"Variable ", shQuote(numvars[i])," has not been modified.\n\n"))
         }
       } else {
+        anyChanges <- TRUE
         summary_o <- summary(nv_o[,i])
         summary_m <- summary(as.numeric(nv_m[,i]))
         val_cor <- cor(nv_o[,i], nv_m[,i], use="pairwise.complete.obs")
@@ -461,6 +468,7 @@ definition = function(x, type = "kAnon", docat=TRUE, ...) {
         out$results[[length(out$results)+1]] <- dt
       }
     }
+    if(!anyChanges){out$results <- NULL} # if no changes, NULL
     if (docat) {
       cat(hr,"\n\n")
     }

--- a/R/printFunctions.R
+++ b/R/printFunctions.R
@@ -468,7 +468,9 @@ definition = function(x, type = "kAnon", docat=TRUE, ...) {
         out$results[[length(out$results)+1]] <- dt
       }
     }
-    if(!anyChanges){out$results <- NULL} # if no changes, NULL
+    if (!anyChanges) {
+      out$results <- NULL
+    }
     if (docat) {
       cat(hr,"\n\n")
     }

--- a/inst/shiny/sdcApp/server.R
+++ b/inst/shiny/sdcApp/server.R
@@ -539,7 +539,7 @@ shinyServer(function(session, input, output) {
     return(list(cmd=cmd, cmd_strata1=cmd_strata1, cmd_strata2=cmd_strata2, txt_action=txt_action))
   })
 
-  # code for microaggregation()
+  # code for addNoise()
   code_addNoise <- reactive({
     n_method <- input$sel_noise_method
     cmd <- paste0("sdcObj <- addNoise(obj=sdcObj")


### PR DESCRIPTION
Solves problem that if not all numerical variables are changed, the
summary view in the GUI was wrong (table was filled up and duplicated
results). Proposed solution to adapt the print function: dt is NULL if
no changes, if any variable changes it also includes the summary
statistics for the remaining variables (without changes). Alternative
would be to only show the changed variables in the GUI

plus small correction to comment