### PR TITLE
Adding summary statistics to decide on threshold and replacement value for topcoding

### DIFF
--- a/inst/shiny/sdcApp/controllers/ui_continuous.R
+++ b/inst/shiny/sdcApp/controllers/ui_continuous.R
@@ -152,8 +152,22 @@ output$ui_topbotcoding_num <- renderUI({
       }
       N <- length(na.omit(vv))
       p <- formatC(100*(n/N), format="f", digits=2)
+      
+      vv_before <- curObj@origData[[input$sel_topbot_var_num]]
+      if(length(get_weightVar_name()) > 0){ weight_gini <- curObj@origData[[get_weightVar_name()]]}else{ weight_gini <- rep(1, length(vv))} 
+      gini_before <- round(laeken::gini(vv_before, weights = weight_gini, na.rm = TRUE)$value, digits = 3)
+      vv_after <- vv
+      if (input$sel_topbot_kind_num=="top") {
+        vv_after[!is.na(vv) & vv >= num1] <- num2
+      } else {
+        vv_after[!is.na(vv) & vv <= num1] <- num2
+      }
+      gini_after  <- round(laeken::gini(vv_after, weights = weight_gini, na.rm = TRUE)$value, digits = 3)
       return(fluidRow(
         column(12, p(code(n),"(out of",code(N),") values will be replaced. This equals",code(p),"percent of the data."), align="center"),
+        column(12, p("The weighted Gini coefficient of the original variable is", code(gini_before),
+                     ". After top or bottom coding with the selected threshold and replacement value, the Gini coefficient will change to", code(gini_after),
+                     "."), align="center"),
         column(12, myActionButton("btn_topbotcoding_num",label=("Apply Top/Bottom-Coding"), "primary"), align="center")
       ))
     } else {


### PR DESCRIPTION
Hi,

while applying top (or bottom) coding, we have found it useful to have some standard summary statistics that allow you to make informed decisions on the threshold value. Here we were thinking of some percentiles, the mean plus 1/2/3 standard deviations for the spread, the number of non-missing values and the n largest values. For the replacement value, it would be useful to see the average of the values above the selected replacement value. We think it would be an enhancement for the GUI user to see these values in the GUI (See screenshot). This pull request proposes some code to add these suggestions to the GUI.

![schermafbeelding 2017-12-21 om 19 18 13](https://user-images.githubusercontent.com/8253935/34269242-db4ce74c-e683-11e7-9362-f056373b628d.png)

