### PR TITLE
Add haven_labelled due to change in haven package

### DIFF
--- a/R/GUIfunctions.R
+++ b/R/GUIfunctions.R
@@ -452,9 +452,9 @@ readMicrodata <- function(path, type, convertCharToFac=TRUE, drop_all_missings=T
     res[is.na(res)] <- NA
   }
 
-  # check if any variable has class 'labelled' and convert it to factors.
+  # check if any variable has class 'labelled' or 'haven_labelled' (from haven 2.0.0) and convert it to factors.
   # this might happen if we read data with read_xxx() from haven
-  cl_lab <- which(sapply(res, class)=="labelled")
+  cl_lab <- which(sapply(res, class) %in% c("labelled", "haven_labelled"))
   if (length(cl_lab) > 0) {
     if (length(cl_lab)==1) {
       res[[cl_lab]] <- as_factor(res[[cl_lab]], levels="default")


### PR DESCRIPTION
From version 2.0.0 of the haven package (release November 2018), labelled variables are imported as class "haven_labelled" instead of class "labelled". This class needs to be added. In order to accomodate for users of older and newer versions of the haven package, I suggest to keep both.