### PR TITLE
Adding default comment.char parameter for csv imports

### DIFF
--- a/R/GUIfunctions.R
+++ b/R/GUIfunctions.R
@@ -433,7 +433,8 @@ readMicrodata <- function(path, type, convertCharToFac=TRUE, drop_all_missings=T
     header <- ifelse(opts$header==TRUE, TRUE, FALSE)
     sep <- opts$sep
     quote <- "\""
-    res <- tryCatchFn(utils::read.table(path, sep=sep, header=header, quote=quote))
+    comment.char <- ""
+    res <- tryCatchFn(utils::read.table(path, sep=sep, header=header, quote=quote, comment.char=comment.char))
   }
   if ("simpleError" %in% class(res)) {
     return(res)


### PR DESCRIPTION
## Perceived Problem
[Read.table](https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/read.table) has a set of default parameters for csv files under the read.csv function. This includes setting comment.char to "" instead of read.table's default "#".

Your sdcApp gui doesn't set comment.char to "" so if I try to read in a csv with an unescaped hash, the GUI errors. 

## Rationale for change
I propose this change so the sdcMicro import behavior for csv follows read.csv's default parameters. I think this will make debugging easier as the GUI behaves like read.csv.

## Steps to reproduce

### this csv file will error on record one
```csv
foo,bar
#hello,world
hello,world
```
### this csv will pass with two records
```csv
foo,bar
hello,world
hello,world
```
### this csv will pass with two records
```csv
foo,bar
"#hello",world
hello,world
```

## Workaround
This isn't a blocker as I'm just reading my csv directly using read.csv and not using the sdcApp gui's CSV import, but this may be confusing to others wondering why read.csv parses their CSV file, but sdcApp doesnt.

Great package by the way, it's been so helpful.