### PR TITLE
allow change of max_size for undo-functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -94,6 +94,6 @@ Collate:
     'maG.R'
     'sdcApp.R'
     'show_sdcMicroObj.R'
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+# 5.6.2
+- allow to change fixed threshold for undo-feature using env-var `sdcMicro_maxsize_undo`
+
 # 5.6.1
 - various fixes in `sdcApp()`, e. g:
    * pram (expert) button is now shown again

--- a/R/aux_functions.r
+++ b/R/aux_functions.r
@@ -125,6 +125,19 @@ createSdcObj <- function(dat, keyVars, numVars=NULL, pramVars=NULL, ghostVars=NU
     options$seed <- NA
   }
 
+  # max_size for undo-functionality (refers to rows of data.frame input
+  # can be set via env-var `sdcMicro_maxsize_undo`
+  res <- tryCatch(
+    expr = as.numeric(Sys.getenv("sdcMicro_maxsize_undo")),
+    error = function(e) e,
+    warning = function(w) w
+  )
+  if (inherits(res, "error") || is.na(res) || res < 1) {
+    options$max_size <- 1e5
+  } else {
+    options$max_size <- res
+  }
+
   if (!is.data.frame(dat)) {
     dat <- as.data.frame(dat)
   }
@@ -284,21 +297,39 @@ setGeneric("nextSdcObjX", function(obj) {
 })
 
 setMethod(f="nextSdcObjX", signature=c("sdcMicroObj"), definition=function(obj) {
-  options <- get.sdcMicroObj(obj, type="options")
+  options <- get.sdcMicroObj(obj, type = "options")
   if (("noUndo" %in% options)) {
     return(obj)
   }
-  if (nrow(obj@origData) > 1e+05) {
-    warnMsg <- "No previous states are saved because your data set has more than 100 000 observations.\n"
-    obj <- addWarning(obj, warnMsg=warnMsg, method="nextSdcObj", variable=NA)
+  if (nrow(obj@origData) > options$max_size) {
+    warnMsg <- paste("No previous states are saved because your data set has more than", options$max_size, "observations.\n")
+    obj <- addWarning(
+      obj = obj,
+      warnMsg = warnMsg,
+      method = "nextSdcObj",
+      variable = NA
+    )
     warning(warnMsg)
     return(obj)
   }
-  if (length(grep("maxUndo", options)) > 0)
-    maxUndo <- as.numeric(substr(options[grep("maxUndo", options)], 9, stop=nchar(options[grep("maxUndo",
-      options)], type="width"))) else maxUndo <- 1
-  obj <- deletePrevSave(obj, maxUndo)
-  obj <- set.sdcMicroObj(obj, type="prev", input=list(obj))
+  if (length(grep("maxUndo", options)) > 0) {
+    maxUndo <- as.numeric(substr(
+      x = options[grep("maxUndo", options)],
+      start = 9,
+      stop = nchar(options[grep("maxUndo", options)], type = "width")
+    ))
+  } else {
+    maxUndo <- 1
+  }
+  obj <- deletePrevSave(
+    obj = obj,
+    m = maxUndo
+  )
+  obj <- set.sdcMicroObj(
+    object = obj,
+    type = "prev",
+    input = list(obj)
+  )
   return(obj)
 })
 

--- a/R/sdcMicro-package.R
+++ b/R/sdcMicro-package.R
@@ -173,8 +173,15 @@
 #' marstat <- as.factor(free1[,"MARSTAT"])
 #' marstatPramed <- pram(marstat)
 #' summary(marstatPramed)
+#'
 #' # FOR OBJECTS OF CLASS sdcMicro
 #' data(testdata)
+#'
+#' # undo-functionality is by default restricted to data sets
+#' # with <= 1e5 rows; to modify, env-var `sdcMicro_maxsize_undo`
+#' # can to be changed before creating a problem instance
+#' Sys.setenv("sdcMicro_maxsize_undo" = 1e6)
+#'
 #' sdc <- createSdcObj(testdata,
 #'   keyVars=c('urbrur','roof','walls','water','electcon','relat','sex'),
 #'   numVars=c('expend','income','savings'), w='sampling_weight')

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,3 +7,7 @@
   msg <- paste0(msg,"--------")
   packageStartupMessage(msg)
 }
+
+.onAttach <- function(lib, pkg) {
+  Sys.setenv("sdcMicro_maxsize_undo" = 1e5)
+}

--- a/man/sdcMicro-package.Rd
+++ b/man/sdcMicro-package.Rd
@@ -147,6 +147,12 @@ marstatPramed <- pram(marstat)
 summary(marstatPramed)
 # FOR OBJECTS OF CLASS sdcMicro
 data(testdata)
+
+# undo-functionality is by default restricted to data sets
+# with <= 1e5 rows; to modify, env-var `sdcMicro_maxsize_undo`
+# needs to be changed before creating a problem instance
+Sys.setenv("sdcMicro_maxsize_undo" = 2e5)
+
 sdc <- createSdcObj(testdata,
   keyVars=c('urbrur','roof','walls','water','electcon','relat','sex'),
   numVars=c('expend','income','savings'), w='sampling_weight')


### PR DESCRIPTION
hi @matthias-da, this pr adresses #317 by introducing an environment variable `sdcMicro_maxsize_undo` which is read in `sdcMicro::createSdcObj` and stored as option-parameter; it has the default value of `1e5` (the previously hard-coded threshold value) and also falls back to this value if no suitable number (empty, missing, <1) is stored in this environment variable.

Using this approach, it is not required to add additional parameters to any functions;