### PR TITLE
Fix warning: explicitly assigning value of variable of type '<type>' to itself by removing the keyword parameter pass.

### DIFF
--- a/src/recordSwap_R.cpp
+++ b/src/recordSwap_R.cpp
@@ -65,9 +65,9 @@ std::vector< std::vector<int> > recordSwap_cpp(std::vector< std::vector<int> > d
                                                       risk, risk_threshold,
                                                       k_anonymity, risk_variables,
                                                       carry_along,
-                                                      count_swapped_records = count_swapped_records,
-                                                      count_swapped_hid = count_swapped_hid,
-                                                      log_file_name = log_file_name,
+                                                      count_swapped_records,
+                                                      count_swapped_hid,
+                                                      log_file_name,
                                                       seed);
 
   return output;


### PR DESCRIPTION
Fix a compiler warning related to the use of a named argument call in `recordSwap_cpp()` by removing the parameter assignment. 

Error messages: 

```
recordSwap_R.cpp:68:77: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                                                      count_swapped_records = count_swapped_records,
                                                      ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~
recordSwap_R.cpp:69:73: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                                                      count_swapped_hid = count_swapped_hid,
                                                      ~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
recordSwap_R.cpp:70:69: warning: explicitly assigning value of variable of type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>') to itself [-Wself-assign-overloaded]
                                                      log_file_name = log_file_name,
                                                      ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
````