### PR TITLE
Update if(nrow(risk)>0) in recordSwap

### DIFF
--- a/R/recordSwap.R
+++ b/R/recordSwap.R
@@ -351,7 +351,8 @@ recordSwap.default <- function(data, hid, hierarchy, similar,
       }
     }
 
-    if(any(risk<0)||any(!is.numeric(risk))){
+    if(any(risk<0)||any(!unlist(lapply(risk, is.numeric)))
+      ){
       stop("risk must contain positive real values only!")
     }
   }


### PR DESCRIPTION
Because of this command `risk <- data.table(risk)` the matrix is always converted into the data.table  So then the check of numeric values `any(!is.numeric(risk))` always fails. So I repaired it.

Doesn't work
>     any(!is.numeric(risk))
>     [1] TRUE
>     is.numeric(risk)
>     [1] FALSE

Individualy numeric is ok
>     is.numeric(risk$V1)
>     [1] TRUE
>     is.numeric(risk$V2)
>     [1] TRUE

My solution
>     unlist(lapply(risk, is.numeric))
>       V1   V2 
>     TRUE TRUE 


>     any(!unlist(lapply(risk, is.numeric)))
>     [1] FALSE