### PR TITLE
Big update of recordSwap 

### DIFF
--- a/R/recordSwap.R
+++ b/R/recordSwap.R
@@ -90,7 +90,7 @@
 #' in a household for each member of the household. If this condition is not      
 #' satisfied, the risk parameter is automatically adjusted to comply with this    
 #' condition.
-#'  If risk parameter is provided then k-anonymity rule is suppressed.
+#' If risk parameter is provided then k-anonymity rule is suppressed.
 #' @param risk_threshold single numeric value indicating when a household is
 #' considered "high risk", e.g. when this household must be swapped. Is only
 #' used when `risk` is not `NULL`.

--- a/R/recordSwap.R
+++ b/R/recordSwap.R
@@ -6,7 +6,7 @@
 #' @details The procedure accepts a `data.frame` or `data.table`
 #' containing all necessary information for the record swapping, e.g
 #' parameter `hid`, `similar`, `hierarchy`, etc ...
-#' First the micro data in `data` is ordered by `hid` and the identification
+#' First, the micro data in `data` is ordered by `hid` and the identification
 #' risk is calculated for each record in each hierarchy level. As of right
 #' now only counts is used as identification risk and the inverse of counts
 #' is used as sampling probability.
@@ -18,33 +18,34 @@
 #' risky households in each hierarchy level. A household is set to risky
 #' if counts < k_anonymity in any hierarchy level and the household needs
 #' to be swapped across this hierarchy level.
-#' For instance having a geographic hierarchy of NUTS1 > NUTS2 > NUTS3 the
+#' For instance, having a geographic hierarchy of NUTS1 > NUTS2 > NUTS3 the
 #' counts are calculated for each geographic variable and defined
 #' `risk_variables`. If the counts for a record falls below `k_anonymity`
-#' for hierarchy county then this record needs to be swapped across counties.
+#' for hierarchy county (NUTS1, NUTS2, ...) then this record needs to be swapped 
+#' across counties.
 #' Setting `k_anonymity = 0` disables this feature and no risky households
 #' are defined.
 #'
-#' After that the targeted record swapping is applied starting from the highest
+#' After that the targeted record swapping is applied, starting from the highest
 #' to the lowest hierarchy level and cycling through all possible geographic
 #' areas at each hierarchy level, e.g every county, every municipality in
 #' every county, etc, ...
 #'
-#' At each geographic area a set of values is created for records to be
-#' swapped. In all but the lowest hierarchy level this is ONLY made out
-#' of all records which do not fulfill the k-anonymity and have not already
+#' At each geographic area, a set of values is created for records to be
+#' swapped. In all but the lowest hierarchy level, this is ONLY made out
+#' of all records which do not fulfil the k-anonymity and have not already
 #' been swapped. Those records are swapped with records not belonging to
 #' the same geographic area, which have not already been swapped beforehand.
 #' Swapping refers to the interchange of geographic variables defined in
-#' `hierarchy`. When a record is swapped all other record containing the
+#' `hierarchy`. When a record is swapped all other records containing the
 #' same `hid` are swapped as well.
 #'
-#' At the lowest hierarchy level in every geographic area the set of records to
-#' be bswapped is made up of all records which do not fulfill the k-anonymity
-#' as well as the remaining numer of records such that the proportion of
+#' At the lowest hierarchy level in every geographic area, the set of records to
+#' be swapped is made up of all records which do not fulfil the k-anonymity
+#' as well as the remaining number of records such that the proportion of
 #' swapped records of the geographic area is in coherence with the `swaprate`.
-#' If, due to the k-anonymity condition, more records have already been swapped
-#' in this geographic area then only the records which do not fulfill the
+#' If due to the k-anonymity condition, more records have already been swapped
+#' in this geographic area then only the records which do not fulfil the
 #' k-anonymity are swapped.
 #'
 #' Using the parameter `similar` one can define similarity profiles.
@@ -62,7 +63,7 @@
 #'
 #' `swaprate` sets the swaprate of households to be swapped, where a single
 #' swap counts for swapping 2 households, the sampled household and the
-#' corresponding donor. Prior to the procedure the swaprate is applied on
+#' corresponding donor. Prior to the procedure, the swaprate is applied on
 #' the lowest hierarchy level, to determine the target number of swapped
 #' households in each of the lowest hierarchies. If the target numbers of a
 #' decimal point they will randomly be rounded up or down such that the
@@ -85,13 +86,18 @@
 #' at each hierarchy level. If `risk`-matrix is supplied to swapping procedure
 #' will not use the k-anonymity rule but the values found in this matrix
 #' for swapping.
-#' ATTENTION: This is NOT fully implemented yet and currently ignored by the
-#' underlying c++ functions until tested properly
+#' When using the risk parameter is expected to have assigned a maximum value     
+#' in a household for each member of the household. If this condition is not      
+#' satisfied, the risk parameter is automatically adjusted to comply with this    
+#' condition.
+#'  If risk parameter is provided then k-anonymity rule is suppressed.
 #' @param risk_threshold single numeric value indicating when a household is
 #' considered "high risk", e.g. when this household must be swapped. Is only
 #' used when `risk` is not `NULL`.
-#' ATTENTION: This is NOT fully implemented yet and currently ignored by the
-#' underlying c++ functions until tested properly
+#' Risk threshold indicates households that have to be swapped, but be aware      
+#' that households with risk lower than threshold, but with still high enough      
+#' risk may be swapped as well. Only households with risk set to 0 are not swapped.                                                   
+#' Risk and risk threshold must be equal or bigger then 0.  
 #' @param k_anonymity integer defining the threshold of high risk households
 #' (counts<k) for using k-anonymity rule
 #' @param risk_variables column indices or column names of variables in `data`

--- a/tests/testthat/test_recordSwap_inputs.R
+++ b/tests/testthat/test_recordSwap_inputs.R
@@ -17,6 +17,13 @@ hier <- c("nuts1","nuts2","nuts3")
 risk_variables <- c("ageGroup","national")
 hid <- "hid"
 
+risk <- matrix(
+  data = rep(1,3*dim(dat)[1]),
+  ncol = 3
+)
+colnames(risk)  <- c("a","b","c")
+risk_threshold <- 0.9
+
 # test input parameter
 test_that("test para - data, hid, hierarchy, similar, risk_variables, carry_along",{
   
@@ -265,4 +272,143 @@ test_that("test para - swaprate, k_anonymity, return_swapped_id, seed",{
                           carry_along = NULL,
                           return_swapped_id = TRUE,
                           seed=c("a","b")),"seed must be a single positive integer!")
+})
+
+# test risk and risk_threshold
+test_that("test para - risk, risk_threshold",{
+  
+  #################################
+  # risk
+  
+  # test: if(is.vector(risk)){ if(length(risk) == nrow(data)) }
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = c("nuts1","nuts2"), # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = rep(1,dim(dat)[1]), # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "If risk is not a vector containing column indices or column names in data then risk must be either a data.table, data.frame or matrix!")
+  
+  # test: if(is.vector(risk)){ if(length(risk)!=length(hierarchy)) }
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = c("nuts1","nuts2"), # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = 1, # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "risk and hierarchy need to address the same number of columns!")
+  
+  # test:  if(is.vector(risk)){ checkIndexString(risk,cnames,minLength = 1) }
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = c("nuts1","nuts2"), # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = list("nuts1" = rep(1,dim(dat)[1]), 
+                                      "nuts2" = rep(1,dim(dat)[1])
+                          ), # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               # "checkIndexString(risk, cnames, minLength = 1) : 
+               "If risk is not a vector containing column indices or column names in data then risk must be either a data.table, data.frame or matrix!")
+  
+  # test: if(nrow(risk)>0){ if(ncol(risk)!=length(hierarchy)) }
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = c("nuts1","nuts2"), # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = matrix(data = rep(1,3*dim(dat)[1]),
+                                        ncol = 3
+                          ), # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "number of columns in risk does not match number of hierarchies!")
+  
+  # test: if(is.null(cnamesrisk)){}else{ if(!any(cnamesrisk%in%cnames[hierarchy+1])){} }
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = hier, # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = risk, # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "the columnnames of risk do not appear in data")
+  
+  # test: if(any(risk<0)||any(!unlist(lapply(risk, is.numeric))))
+  expect_error(recordSwap(data = dat, hid = hid, 
+                          hierarchy = hier, # TESTING
+                          similar = similar,
+                          swaprate = swaprate,
+                          k_anonymity = k_anonymity,
+                          risk_variables = risk_variables,
+                          risk = matrix(
+                            data = rep(-1,3*dim(dat)[1]),
+                            ncol = 3
+                          ), # TESTING
+                          risk_threshold = risk_threshold, 
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "risk must contain positive real values only!")
+  
+  #################################
+  # risk_threshold
+  
+  # test: is.numeric(risk_threshold) 
+  expect_error(recordSwap(data = dat, hid = hid, hierarchy = hier,
+                          similar = similar, swaprate = swaprate,
+                          k_anonymity = k_anonymity,      
+                          risk = risk, # TESTING
+                          risk_threshold = "A", # TESTING
+                          risk_variables = risk_variables,
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "risk_threshold must be a positiv numeric value")     
+  
+  # test: length(risk_threshold)==1    
+  expect_error(recordSwap(data = dat, hid = hid, hierarchy = hier,
+                          similar = similar, swaprate = swaprate,
+                          k_anonymity = k_anonymity,  
+                          risk = risk, # TESTING
+                          risk_threshold = c(0.5,2), # TESTING
+                          risk_variables = risk_variables,
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "risk_threshold must be a positiv numeric value")     
+  
+  # test: risk_threshold>=0
+  expect_error(recordSwap(data = dat, hid = hid, hierarchy = hier,
+                          similar = similar, swaprate = swaprate,
+                          k_anonymity = k_anonymity,       
+                          risk = risk, # TESTING
+                          risk_threshold = -1, # TESTING
+                          risk_variables = risk_variables,
+                          carry_along = NULL,
+                          return_swapped_id = TRUE,
+                          seed=seed),
+               "risk_threshold must be a positiv numeric value")
+  
 })

--- a/tests/testthat/test_recordSwap_outputs.R
+++ b/tests/testthat/test_recordSwap_outputs.R
@@ -10,13 +10,24 @@ set.seed(seed)
 nhid <- 10000
 dat <- sdcMicro::createDat( nhid )
 
-k_anonymity <- 0
+k_anonymity <- 1
 swaprate <- .05
 similar <- list(c("hsize"))
 hier <- c("nuts1","nuts2","nuts3")
 risk_variables <- c("ageGroup","national")
 hid <- "hid"
 expect_swaps <- swaprate * nhid
+
+# risk
+risk <- matrix(
+  data = rep(0.0001,3*dim(dat)[1]), # 0.0001 to swap all risky hd
+  ncol = 3
+) 
+set.seed(seed)
+index <- sample(1:(length(hier)*nrow(dat)), 
+                size = expect_swaps)
+risk[index] <- 99 # risk value
+risk_threshold <- 0.9
 
 # test input parameter
 test_that("test households correctly swapped",{
@@ -80,6 +91,7 @@ test_that("test number of swapped households",{
   expect_true(dat_s[hid!=hid_swapped,uniqueN(hid)]==(.25*nhid))
 })
 
+
 test_that("test carry along output",{
   carry_along <- c("lau2")
   dat_s <- recordSwap(data = dat, hid = hid, hierarchy = hier,
@@ -116,7 +128,7 @@ test_that("test k anonymity levels",{
   
   hier <- c("nuts1","nuts2")
   risk_variables <- c("ageGroup","national","hsize")
-  k_anonymity <- 1
+  k_anonymity <- 2
   # check if all risk households are swapped
   dat_s <- recordSwap(data = dat, hid = hid, hierarchy = hier,
                       similar = similar, swaprate = swaprate,
@@ -206,3 +218,150 @@ test_that("test similarity profiles",{
 })
 
 
+test_that("test risk parameter - number of hd swaps)",{
+  
+  dat_s <- recordSwap(data = dat, hid = hid, hierarchy = hier,
+                      similar,
+                      risk = risk, # TESTING
+                      risk_threshold = risk_threshold, # TESTING
+                      carry_along = NULL,
+                      return_swapped_id = TRUE,
+                      seed=seed,
+                      swaprate = 0 # to test swaping based only on risk values
+  )
+  
+  # check that swapped regions are identical for each household
+  dat_check <- dat_s[,lapply(.SD,uniqueN),by=.(hid),.SDcols=c(hier)]
+  expect_true(all(dat_check[,!..hid]==1))
+  
+  # check that region was actually swapped correctly
+  dat1 <- unique(dat[,.SD,.SDcols=c(hid,hier)])
+  dat1[,region:=do.call(paste,.SD),.SDcols=c(hier)]
+  dat2 <- unique(dat_s[,.SD,.SDcols=c(hier,paste0(hid,"_swapped"))])
+  dat2[,region2:=do.call(paste,.SD),.SDcols=c(hier)]
+  setnames(dat2,paste0(hid,"_swapped"),hid)
+  dat_check <- merge(dat1,dat2,by="hid")
+  expect_true(all(dat_check[,region==region2]))
+  
+  # check if all risk households are swapped
+  risk_check <- copy(data.table(risk))
+  risk_variables_names <- copy(colnames(risk_check))
+  risk_check[,hid_help:=dat[[5]]] # 5 = hid
+  risk_check[,c(risk_variables_names):=lapply(.SD,max),
+             .SDcols=c(risk_variables_names),
+             by=.(hid_help)] # assign to each household its max value
+  risk_check_uniq <- unique(risk_check
+  ) # calculate max value in household
+  risk_check_uniq[, Sum := rowSums(.SD), .SDcols = 1:3]
+  n_of_hd_to_swap <- sum(risk_check_uniq$Sum > 1
+  ) # number of households that should be swapped
+  n_of_swapped_hd <- dat_s[hid != hid_swapped, uniqueN(hid)
+  ] # number of swapped households
+  
+  # So what is difference in households
+  hd_to_swap <- risk_check_uniq$hid_help[risk_check_uniq$Sum > 1
+  ] # number of households that was should be swapped
+  swapped_hd <- dat_s[hid != hid_swapped, unique(hid)
+  ] # number of swapped households
+  
+  hd_check <- hd_to_swap[
+    which(!(hd_to_swap %in% swapped_hd))
+  ] # hd to swapp not in swapped hd
+  # swapped_hd[
+  #   which(!(swapped_hd %in% hd_to_swap))
+  # ] # swapped hd not in hd to swap
+  
+  expect_true(is.integer(hd_check) && length(hd_check) == 0L)
+  
+})
+
+test_that("test risk parameter - cpp)",{
+  # In this test, we at first calculate risk value with internal function from 
+  # cpp for the risk calculation. Secondly, we calculate risk values in the same 
+  # way as they are calculated in cpp function. The values shoud be the same. 
+  # After that, we feed recordSwap function with risk calculated in a custom way, 
+  # and we compare it to the risk calculated internally. The values should be 
+  # the same.
+  
+  
+  # calculate risk with cpp function ------------------------------------------
+  dat_t <- transpose(dat)
+  cnames <- colnames(dat)
+  hierarchy <- sdcMicro:::checkIndexString(hier, cnames = cnames, matchLength = length(hier)) 
+  risk_var <- sdcMicro:::checkIndexString(risk_variables, cnames = cnames ,minLength = 1)
+  hid_var <- sdcMicro:::checkIndexString(hid, cnames = cnames ,minLength = 1)  
+  risk_cpp <- sdcMicro:::setRisk_cpp(dat_t,hierarchy,risk_var,hid_var)
+  risk_cpp <- as.data.table(risk_cpp)
+  risk_cpp <- transpose(risk_cpp)
+  
+  
+  # calculate risk in same way as in cpp function  ----------------------------
+  cnames <- colnames(dat)
+  data <- dat
+  hierarchy <- sdcMicro:::checkIndexString(hier, cnames = cnames, matchLength = length(hier)) +1
+  risk_var <- sdcMicro:::checkIndexString(risk_variables, cnames = cnames ,minLength = 1) +1
+  hid_var <- sdcMicro:::checkIndexString(hid, cnames = cnames ,minLength = 1) +1
+  
+  # initialise parameters
+  n <- nrow(dat)
+  nhier <- length(hierarchy)
+  nrisk <- length(risk_variables)
+  
+  risk_calc <- data.table(
+    nuts1 = rep(NA,n),
+    nuts2 = rep(NA,n),
+    nuts3 = rep(NA,n)
+  )
+  
+  for(h in 1:nhier){
+    # ---
+    dat_reg <- data[,c(hierarchy[h],
+                       risk_var),
+                    with = FALSE]
+    names(dat_reg)[1] <- "region"
+    dat_reg$risk_comb <- paste(dat_reg$region, dat_reg$ageGroup, dat_reg$national,
+                               sep = "_")
+    uniqueness <- data.table(table(dat_reg$risk_comb))
+    dat_reg <- merge(x = dat_reg,
+                     y = uniqueness,
+                     by.x = "risk_comb",
+                     by.y = "V1",
+                     sort = FALSE
+    )
+    dat_reg$risk <- 1/dat_reg$N
+    
+    risk_calc[,h] <- dat_reg$risk
+  } # End of for cycle
+  
+  risk_calc[,hid:=data[[hid]]]
+  risk_calc2 <- copy(risk_calc)
+  risk_calc[,c(hier):=lapply(.SD,max),
+            .SDcols=c(hier),
+            by=.(hid)]
+  risk_calc[,hid:=NULL]
+  
+  expect_true(all(risk_calc == risk_cpp))
+  
+  
+  # Test if the results are the same
+  dat_calc <- recordSwap(data = dat, hid = hid, hierarchy = hier,
+                         similar = similar, 
+                         risk = risk_calc, # TESTING
+                         risk_threshold = 0.5, # TESTING
+                         swaprate = 0, # to test swaping based only on risk values
+                         carry_along = NULL,
+                         return_swapped_id = TRUE,
+                         seed=seed
+  )
+  dat_s <- recordSwap(data = dat, hid = hid, hierarchy = hier,
+                      similar = similar, 
+                      risk_variables = risk_variables, # TESTING
+                      k_anonymity = 2, # TESTING
+                      swaprate = 0, # to test swaping based only on risk values
+                      carry_along = NULL,
+                      return_swapped_id = TRUE,
+                      seed=seed
+  )
+  expect_true(all(dat_calc==dat_s))
+  
+})

--- a/vignettes/recordSwapping.Rmd
+++ b/vignettes/recordSwapping.Rmd
@@ -389,6 +389,37 @@ Number of swapped `hid`s
 dat_swapped3[!duplicated(hid),.N,by=.(id_swapped = hid!=hid_swapped)]
 ```
 
+### Supplying your own risk values 
+
+Instead of using `k_anonymity` and `risk_variables` for the calculation of a number of swaps, custom risk can be supplied. For custom risk for households can be used parameters `risk` and then the parameter `risk_threshold` is used to determine high-risk households. 
+High-risk households are always swapped, and households with risk lower than the threshold are also used as donor households. To ensure that the household is not swapped, its risk must be set to 0. 
+
+```{r}
+hid <- "hid"
+similar <- list(c("hsize"))
+hier <- c("nuts1","nuts2","nuts3")
+risk_threshold <- 0.9
+# set risk matrix with low risk for everybody
+risk <- matrix(
+  data = rep(0.0001,3*nrow(dat)), 
+  ncol = 3,
+  dimnames = list(1:nrow(dat),
+                  hier)) 
+# for example, assign random people high risk value 
+set.seed(1234L)
+risk[sample(1:(length(hier)*nrow(dat)),size = 50)] <- 99 # risk value
+
+dat_swapped4  <- recordSwap(data = copy(dat), 
+                            hid = hid, 
+                            hierarchy = hier,
+                            similar,
+                            risk = risk, 
+                            risk_threshold = risk_threshold, 
+                            swaprate = 0,
+                            return_swapped_id = TRUE,
+                            seed = 1234L)
+```
+
 ### Information loss
 
 With the function `infoLoss()` one can calculate various information loss measures over a pre defined frequency table.


### PR DESCRIPTION
# A # Documentation ------------------------------------------------
Added descriptive text to the risk and risk threshold parameters. Also, I used Grammarly to check the spelling.

# B # check data ------------------------------------------------------
I realized that you don't check if data are present.
Your check:
>  if(all(!class(data)%in%c("data.table","data.frame"))){
   stop("data must be either a data.table, data.frame")  }

But if I delete the data parameter:
 > recordSwap()
Error in class(data) %in% c("data.table", "data.frame") : 
  argument "data" is missing, with no default

This is interesting because I run your check, and it works in the console. It fails because it cant check the parameter that is missing.
  >   if(all(!class(data)%in%c("data.table","data.frame"))){
    stop("data must be either a data.table, data.frame")
   }
Error: data must be either a data.table, data.frame

So I propose add missing() https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/missing
>  if(missing(data)){
    stop("data is missing, data must be either a data.table, data.frame")}
  if(all(!class(data)%in%c("data.table","data.frame"))){
    stop("data must be either a data.table, data.frame")  }
  
# C # check mandatory parameters ---------------------------------
I realized that you don't check if user provided mandatory parameters. There are only ugly errors.
> recordSwap(data)
Error in checkIndexString(hid, cnames, matchLength = 1) :
argument "hid" is missing, with no default
> recordSwap(data)
Error in checkIndexString(hid, cnames, matchLength = 1) :
argument "hid" is missing, with no default
> recordSwap(data, hid)
Error in checkIndexString(hierarchy, cnames, minLength = 1) :
argument "hierarchy" is missing, with no default
> recordSwap(data, hid, hierarchy)
Error in recordSwap.default(data, hid, hierarchy) : 
  argument "similar" is missing, with no default

So I propose to add missing()
>  if(any(missing("hid"), missing("hierarchy"),missing("similar"))){
    stop("One of mandatory parameters (hid, hierarchy, similar) is missing.")
  }
 
# D # check risk_variables --------------------------------------------
If we want to use k_anonymity and we don't provide risk_variables, we get ugly error. Because the default value of them is risk_variables=NULL
  > recordSwap(data = dat,hid = hid,hierarchy = hier,similar = similar)
Error in checkIndexString(risk_variables, cnames, minLength = 1) : 
  risk_variables must contain integers (column indices) or characters (~column names) of data

So I propose to add a check if we are using k-anonymity by checking that risk is Null and then check if the risk_variables are null
And after that, we check it again, and if it is FALSE and we want to use the risk parameter, then risk_variables must be 0 because if they are NULL then the recordSwap_cpp() crashes the R.
> if(is.null(risk) & is.null(risk_variables)){
    stop("risk_variables are missing for calculation of k-anonymity rule.")
  }
  if(is.null(risk)){
    risk_variables <- checkIndexString(risk_variables,cnames,minLength = 1)
  } else {
    risk_variables <- 0
  }
 
# E # check k_anonymity ---------------------------------------------
If the previous update (D) is accepted, then we can delete its check-in following a check of k_anonymity
>  if(!all((!is.null(risk_variables))&checkInteger(k_anonymity)&length(k_anonymity)==1&k_anonymity>=0)){
    stop("k_anonymity must be a positiv single integer!")
  }

So I propose just delete (!is.null(risk_variables))
>  if(!all(checkInteger(k_anonymity)&length(k_anonymity)==1&k_anonymity>=0)){
    stop("k_anonymity must be a positiv single integer!")
  }
 
# F # check risk_threshold --------------------------------------------
Theoretically could happen that somebody would left there risk_variables and put there badly risk_threshold and then it's not checked. The default value for risk_threshold=0
>  if(is.null(risk_variables)){
    if(!(is.numeric(risk_threshold)&&length(risk_threshold)==1&&risk_threshold>=0)){
      stop("risk_threshold must be a positiv numeric value")    } }
 
 So I propose remove is.null(risk_variables) and test in the same way as k_anonymity and swaprate
>  if(!(is.numeric(risk_threshold)&&length(risk_threshold)==1&&risk_threshold>=0)){
    stop("risk_threshold must be a positiv numeric value!")  }

# G # check risk -------------------------------------------------------
Here we want from the user just either column indices or column names.
User but can provide only one column of risk values e.g. `risk = rep(1,dim(dat)[1])`, but have `hierarchy = c("nuts1","nuts2")`, so then `is.vector(risk)=TRUE`,  but then `length(risk)!=length(hierarchy)` is always `TRUE` because `length(risk)=17670` and `length(hierarchy)=3`.
>  if(is.vector(risk)){
    if(length(risk)!=length(hierarchy)){
      stop("risk and hierarchy need to address the same number of columns!")    }  }

So I propose to check if the vector is of the length of a number of rows of data and if yes, then we tell the user that we don't want risk values in this format. Also, because lists are considered vectors, I just added check if the risk is as a list.
>  if(is.vector(risk)){
    if(any(length(risk) == nrow(data),is.list(risk))){
      stop("If risk is not a vector containing column indices or column names in data then risk must be either a data.table, data.frame or matrix!") }
    if(length(risk)!=length(hierarchy)){
      stop("risk and hierarchy need to address the same number of columns!")   }  }

In case of list, i.e. `risk= list("nuts1" = rep(1,dim(dat)[1]),"nuts2" = rep(1,dim(dat)[1]))` then ` is.vector(risk)=TRUE` , then ` length(risk) == nrow(data)`  is ` FALSE`  and ` length(risk)!=length(hierarchy)`  is ` FALSE`  
and we get error at ` risk <- checkIndexString(risk,cnames,minLength = 1)` 
> Error in checkIndexString(risk, cnames, minLength = 1) : 
  risk must contain integers (column indices) or characters (~column names) of data									  

# H # cnamesrisk -----------------------------------------------------		
I got some weird errors in the check of risk and realized that the logical check is wrong
>      if(!any(cnamesrisk)%in%cnames[hierarchy+1]){
        stop("the columnnames of risk do not appear in data")  
      }

We will get the following error
>Error in recordSwap.default(data, hid, hierarchy, similar, risk = risk,  : 
  the columnnames of risk do not appear in data
In addition: Warning message:
In any(cnamesrisk) : coercing argument of type 'character' to logical

So I repaired it.
>      if(!any(cnamesrisk%in%cnames[hierarchy+1])){
        stop("the columnnames of risk do not appear in data")  
      }

# I # Adjustment of households in risk parameter -----------------
With @JohannesGuss I prepared to check the values of risk variables if they need adjustment for recordSwap_cpp()
This checks if risk values in each household are unique and if not, then assigns every member of the household the highest value in the household.				  
>    risk_variables_names <- copy(colnames(risk))
    risk[,hid_help:=data[[hid+1]]]
    tryCatch(
      expr = risk[,lapply(.SD,
                          function(z){
                            if( (length(unique(z)) > 1)) {stop()} else {0}
                          }), # error when value not equal 0
                  .SDcols=c(risk_variables_names),
                  by=.(hid_help)], # calculate if each household have unique values
      error  = function(e){ 
        message("risk was adjusted in order to give each household member the maximum household risk value")
        risk[,c(risk_variables_names):=lapply(.SD,max),
             .SDcols=c(risk_variables_names),
             by=.(hid_help)] # assign to each household its max value
        risk[,hid_help:=NULL]
      }
    )
  }

# J # Updated recordSwap input tests ------------------------------
Into input tests for recordswap were added tests to test every error properly.

# K # Updated recordSwap output tests ----------------------------
Into output tests for recordswap were added tests to test it properly.

# L # Updated vignette of recordSwapping -------------------------
Into the vignette of recordSwap was added an example for supplying your own risk into the function.
