### PR TITLE
improvements to recordSwapn()

### DIFF
--- a/tests/testthat/test_recordSwap_inputs.R
+++ b/tests/testthat/test_recordSwap_inputs.R
@@ -103,7 +103,7 @@ test_that("test para - data, hid, hierarchy, similar, risk_variables, carry_alon
              risk_variables = risk_variables,
              carry_along = NULL,
              return_swapped_id = TRUE,
-             seed=seed),"Columns specified in hid, hierarchy, similar and carry\\_along must contain only integer values at this point")
+             seed=seed),"Columns specified in hid, hierarchy, similar, risk_variables and carry\\_along must contain only integer values at this point")
   dat[,c("h_extra","h_extra2"):=NULL]
   #################################
   

--- a/tests/testthat/test_recordSwap_outputs.R
+++ b/tests/testthat/test_recordSwap_outputs.R
@@ -220,15 +220,15 @@ test_that("test similarity profiles",{
 
 test_that("test risk parameter - number of hd swaps)",{
   
-  dat_s <- recordSwap(data = dat, hid = hid, hierarchy = hier,
-                      similar,
-                      risk = risk, # TESTING
-                      risk_threshold = risk_threshold, # TESTING
-                      carry_along = NULL,
-                      return_swapped_id = TRUE,
-                      seed=seed,
-                      swaprate = 0 # to test swaping based only on risk values
-  )
+  dat_s <- expect_warning(recordSwap(data = dat, hid = hid, hierarchy = hier,
+                                     similar,
+                                     risk = risk, # TESTING
+                                     risk_threshold = risk_threshold, # TESTING
+                                     carry_along = NULL,
+                                     return_swapped_id = TRUE,
+                                     seed=seed,
+                                     swaprate = 0 # to test swaping based only on risk values
+  ),"risk was adjusted in order to give each household member the maximum household risk value")
   
   # check that swapped regions are identical for each household
   dat_check <- dat_s[,lapply(.SD,uniqueN),by=.(hid),.SDcols=c(hier)]


### PR DESCRIPTION
recordSwap() - hid, risk_variables, hierarchy, similar and carry_along now accept factor variables as inputs
Input checking has been improved, previously supplying a factor to hid resulted in very long pre-processing times